### PR TITLE
BAU: Add `/acsp-members` route

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -3,6 +3,7 @@ group: api
 
 weight: 100
 routes:
-  1: ^/acsp-members/*
-  2: ^/internal/acsp-members/*
-  3: ^/acsp-manage-users-api/healthcheck
+  1: ^/acsp-members
+  2: ^/acsp-members/*
+  3: ^/internal/acsp-members/*
+  4: ^/acsp-manage-users-api/healthcheck

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -7,7 +7,7 @@ locals {
   container_port             = "8080" # default Java port to match start script
   docker_repo                = "acsp-manage-users-api"
   lb_listener_rule_priority  = 20
-  lb_listener_paths          = ["/acsp-manage-users-api/healthcheck", "/acsp-members/*", "/internal/acsp-members/*"]
+  lb_listener_paths          = ["/acsp-manage-users-api/healthcheck", "/acsp-members/*", "/acsp-members", "/internal/acsp-members/*"]
   healthcheck_path           = "/acsp-manage-users-api/healthcheck" #healthcheck path for acsp-manage-users-api service
   healthcheck_matcher        = "200"
   application_subnet_ids     = data.aws_subnets.application.ids


### PR DESCRIPTION
- Adding `/acsp-members` base route for exposing endpoints on pheonix