### PR TITLE
IDVA6-1322 acsp manage users api to fetch logged in user memberships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # BlueJ files
 *.ctxt
 
+# IDE metadata
+.idea
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
@@ -22,5 +25,8 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# local application config
+application-local.properties
 
 target

--- a/src/main/java/uk/gov/companieshouse/acsp/manage/users/controller/UserAcspMembershipController.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/manage/users/controller/UserAcspMembershipController.java
@@ -1,0 +1,46 @@
+package uk.gov.companieshouse.acsp.manage.users.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.acsp.manage.users.model.UserContext;
+import uk.gov.companieshouse.acsp.manage.users.service.AcspMembersService;
+import uk.gov.companieshouse.acsp.manage.users.utils.StaticPropertyUtil;
+import uk.gov.companieshouse.api.acsp_manage_users.api.UserAcspMembershipInterface;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembershipsList;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.Objects;
+
+@RestController
+public class UserAcspMembershipController implements UserAcspMembershipInterface {
+
+  private final AcspMembersService acspMembersService;
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(StaticPropertyUtil.APPLICATION_NAMESPACE);
+
+  public UserAcspMembershipController(final AcspMembersService acspMembersService) {
+    this.acspMembersService = acspMembersService;
+  }
+
+  @Override
+  public ResponseEntity<AcspMembershipsList> getAcspMembershipsForUserId(
+      final String xRequestId, final String ericIdentity, final Boolean includeRemoved) {
+    LOG.info(
+        String.format(
+            "Received request for GET `/memberships` with X-Request-Id: %s, ERIC-Identity: %s, includeRemoved: %s",
+            xRequestId, ericIdentity, includeRemoved));
+    final var loggedUser = UserContext.getLoggedUser();
+    final var acspMemberships =
+        acspMembersService.fetchAcspMemberships(Objects.requireNonNull(loggedUser), includeRemoved);
+    LOG.infoContext(
+        xRequestId,
+        String.format(
+            "Successfully fetched ACSP memberships for the user with ID %s",
+            loggedUser.getUserId()),
+        null);
+    return new ResponseEntity<>(acspMemberships, HttpStatus.OK);
+  }
+}

--- a/src/main/java/uk/gov/companieshouse/acsp/manage/users/repositories/AcspMembersRepository.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/manage/users/repositories/AcspMembersRepository.java
@@ -1,12 +1,18 @@
 package uk.gov.companieshouse.acsp.manage.users.repositories;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.companieshouse.acsp.manage.users.model.AcspMembersDao;
+
+import java.util.List;
 
 @Repository
 public interface AcspMembersRepository extends MongoRepository<AcspMembersDao, String> {
 
+  @Query(value = "{ 'user_id': ?0 }")
+  List<AcspMembersDao> fetchAllAcspMembersByUserId(final String userId);
+
+  @Query(value = "{ 'user_id': ?0, 'removed_by': null }")
+  List<AcspMembersDao> fetchActiveAcspMembersByUserId(final String userId);
 }
-
-

--- a/src/main/java/uk/gov/companieshouse/acsp/manage/users/service/AcspMembersService.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/manage/users/service/AcspMembersService.java
@@ -1,15 +1,50 @@
 package uk.gov.companieshouse.acsp.manage.users.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.companieshouse.acsp.manage.users.mapper.AcspMembershipListMapper;
+import uk.gov.companieshouse.acsp.manage.users.model.AcspMembersDao;
 import uk.gov.companieshouse.acsp.manage.users.repositories.AcspMembersRepository;
+import uk.gov.companieshouse.acsp.manage.users.utils.StaticPropertyUtil;
+import uk.gov.companieshouse.api.accounts.user.model.User;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembershipsList;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.List;
 
 @Service
 public class AcspMembersService {
 
   private final AcspMembersRepository acspMembersRepository;
+  private final AcspMembershipListMapper acspMembershipsListMapper;
 
-  public AcspMembersService( final AcspMembersRepository acspMembersRepository ) {
-      this.acspMembersRepository = acspMembersRepository;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(StaticPropertyUtil.APPLICATION_NAMESPACE);
+
+  public AcspMembersService(
+      final AcspMembersRepository acspMembersRepository,
+      AcspMembershipListMapper acspMembershipsListMapper) {
+    this.acspMembersRepository = acspMembersRepository;
+    this.acspMembershipsListMapper = acspMembershipsListMapper;
   }
 
+  @Transactional(readOnly = true)
+  public AcspMembershipsList fetchAcspMemberships(final User user, final boolean includeRemoved) {
+    LOG.debug(
+        String.format(
+            "Fetching ACSP memberships from the repository for user ID: %s, include removed: %b",
+            user.getUserId(), includeRemoved));
+
+    List<AcspMembersDao> acspMembers;
+    if (includeRemoved) {
+      acspMembers = acspMembersRepository.fetchAllAcspMembersByUserId(user.getUserId());
+    } else {
+      acspMembers = acspMembersRepository.fetchActiveAcspMembersByUserId(user.getUserId());
+    }
+
+    final var acspMembershipsList = new AcspMembershipsList();
+    acspMembershipsList.setItems(acspMembershipsListMapper.daoToDto(acspMembers, user));
+    return acspMembershipsList;
+  }
 }

--- a/src/test/java/uk/gov/companieshouse/acsp/manage/users/controller/UserAcspMembershipControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/manage/users/controller/UserAcspMembershipControllerTest.java
@@ -1,0 +1,130 @@
+package uk.gov.companieshouse.acsp.manage.users.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.acsp.manage.users.common.TestDataManager;
+import uk.gov.companieshouse.acsp.manage.users.model.UserContext;
+import uk.gov.companieshouse.acsp.manage.users.service.AcspMembersService;
+import uk.gov.companieshouse.acsp.manage.users.service.UsersService;
+import uk.gov.companieshouse.acsp.manage.users.utils.StaticPropertyUtil;
+import uk.gov.companieshouse.api.accounts.user.model.User;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembership;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembershipsList;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserAcspMembershipController.class)
+@Tag("unit-test")
+class UserAcspMembershipControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private StaticPropertyUtil staticPropertyUtil;
+
+  @MockBean private UsersService usersService;
+
+  @MockBean private AcspMembersService acspMembersService;
+
+  private final TestDataManager testDataManager = TestDataManager.getInstance();
+  private User existingUser;
+  private String userId;
+  private AcspMembershipsList acspMembershipsList;
+
+  @BeforeEach
+  void setUp() {
+    userId = "COMU002";
+    existingUser = new User();
+    existingUser.setUserId(userId);
+    when(usersService.fetchUserDetails(existingUser.getUserId())).thenReturn(existingUser);
+    when(usersService.doesUserExist(anyString())).thenReturn(true);
+    UserContext.setLoggedUser(existingUser);
+    acspMembershipsList = new AcspMembershipsList();
+  }
+
+  @Test
+  void getAcspMembershipsForUserIdWithoutXRequestIdReturnsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            get("/user/acsps/memberships")
+                .header("Eric-identity", userId)
+                .header("ERIC-Identity-Type", "oauth2")
+                .header("ERIC-Authorised-Key-Roles", "*"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void getAcspMembershipsForUserIdWithWrongIncludeRemovedParameterInBodyReturnsBadRequest()
+      throws Exception {
+    mockMvc
+        .perform(
+            get("/user/acsps/memberships?include_removed=null")
+                .header("X-Request-Id", "theId123")
+                .header("Eric-identity", userId)
+                .header("ERIC-Identity-Type", "oauth2")
+                .header("ERIC-Authorised-Key-Roles", "*"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void getAcspMembershipsForUserIdWhoHasNoAcspMemebershipsReturnsEmptyAcspMembershipsList()
+      throws Exception {
+    when(usersService.fetchUserDetails(userId))
+        .thenReturn(testDataManager.fetchUserDtos(userId).getFirst());
+
+    acspMembershipsList.setItems(List.of());
+    when(acspMembersService.fetchAcspMemberships(existingUser, false))
+        .thenReturn(acspMembershipsList);
+
+    mockMvc
+        .perform(
+            get("/user/acsps/memberships")
+                .header("X-Request-Id", "theId123")
+                .header("Eric-identity", userId)
+                .header("ERIC-Identity-Type", "oauth2")
+                .header("ERIC-Authorised-Key-Roles", "*"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.items").isArray())
+        .andExpect(jsonPath("$.items.length()").value(0));
+    verify(acspMembersService).fetchAcspMemberships(existingUser, false);
+  }
+
+  @Test
+  void getAcspMembershipsForUserIdWhoHasNoAcspMemebershipsReturnsNonEmptyAcspMembershipsList()
+      throws Exception {
+    when(usersService.fetchUserDetails(userId))
+        .thenReturn(testDataManager.fetchUserDtos(userId).getFirst());
+
+    final var acspMembership = new AcspMembership();
+    acspMembership.setUserId(userId);
+    acspMembershipsList.setItems(List.of(acspMembership));
+    when(acspMembersService.fetchAcspMemberships(existingUser, false))
+        .thenReturn(acspMembershipsList);
+
+    mockMvc
+        .perform(
+            get("/user/acsps/memberships")
+                .header("X-Request-Id", "theId123")
+                .header("Eric-identity", userId)
+                .header("ERIC-Identity-Type", "oauth2")
+                .header("ERIC-Authorised-Key-Roles", "*"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.items").isArray())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].user_id").value(userId));
+    verify(acspMembersService).fetchAcspMemberships(existingUser, false);
+  }
+}

--- a/src/test/java/uk/gov/companieshouse/acsp/manage/users/integration/AcspMembersRepositoryIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/manage/users/integration/AcspMembersRepositoryIntegrationTest.java
@@ -1,0 +1,87 @@
+package uk.gov.companieshouse.acsp.manage.users.integration;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.gov.companieshouse.acsp.manage.users.common.TestDataManager;
+import uk.gov.companieshouse.acsp.manage.users.repositories.AcspMembersRepository;
+import uk.gov.companieshouse.acsp.manage.users.utils.ApiClientUtil;
+import uk.gov.companieshouse.acsp.manage.users.utils.StaticPropertyUtil;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembership;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Testcontainers(parallel = true)
+@Tag("integration-test")
+class AcspMembersRepositoryIntegrationTest {
+
+  @Container @ServiceConnection
+  private static MongoDBContainer container = new MongoDBContainer("mongo:5");
+
+  @Autowired private MongoTemplate mongoTemplate;
+
+  @MockBean private ApiClientUtil apiClientUtil;
+
+  @MockBean private StaticPropertyUtil staticPropertyUtil;
+
+  private final TestDataManager testDataManager = TestDataManager.getInstance();
+
+  @Autowired private AcspMembersRepository acspMembersRepository;
+
+  @Test
+  void fetchAllAcspMembersByUserIdReturnsAllAcspMembersForProvidedUserId() {
+    // Given
+    final var userId = "TSU002";
+    acspMembersRepository.insert(
+        testDataManager.fetchAcspMembersDaos("COM001", "COM002", "COM003", "NF002", "TS002"));
+    // When
+    final var result = acspMembersRepository.fetchAllAcspMembersByUserId(userId);
+    // Then
+    assertEquals(2, result.size());
+    assertTrue(
+        result.stream()
+            .anyMatch(
+                elem ->
+                    elem.getId().equals("NF002")
+                        && elem.getUserId().equals(userId)
+                        && elem.getStatus()
+                            .equals(AcspMembership.MembershipStatusEnum.ACTIVE.getValue())));
+    assertTrue(
+        result.stream()
+            .anyMatch(
+                elem ->
+                    elem.getId().equals("TS002")
+                        && elem.getUserId().equals(userId)
+                        && elem.getStatus()
+                            .equals(AcspMembership.MembershipStatusEnum.REMOVED.getValue())));
+  }
+
+  @Test
+  void fetchActiveAcspMembersByUserIdReturnsActiveAcspMembersForProvidedUserId() {
+    // Given
+    final var userId = "TSU002";
+    acspMembersRepository.insert(
+        testDataManager.fetchAcspMembersDaos("COM001", "COM002", "COM003", "NF002", "TS002"));
+    // When
+    final var result = acspMembersRepository.fetchActiveAcspMembersByUserId(userId);
+    // Then
+    assertEquals(1, result.size());
+    assertTrue(
+        result.stream()
+            .anyMatch(
+                elem ->
+                    elem.getId().equals("NF002")
+                        && elem.getUserId().equals(userId)
+                        && elem.getStatus()
+                            .equals(AcspMembership.MembershipStatusEnum.ACTIVE.getValue())));
+  }
+}

--- a/src/test/java/uk/gov/companieshouse/acsp/manage/users/integration/AcspMembersServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/manage/users/integration/AcspMembersServiceIntegrationTest.java
@@ -1,0 +1,154 @@
+package uk.gov.companieshouse.acsp.manage.users.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.gov.companieshouse.acsp.manage.users.common.TestDataManager;
+import uk.gov.companieshouse.acsp.manage.users.mapper.AcspMembershipListMapper;
+import uk.gov.companieshouse.acsp.manage.users.model.AcspMembersDao;
+import uk.gov.companieshouse.acsp.manage.users.repositories.AcspMembersRepository;
+import uk.gov.companieshouse.acsp.manage.users.service.AcspMembersService;
+import uk.gov.companieshouse.acsp.manage.users.utils.StaticPropertyUtil;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.accounts.user.model.User;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembership;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembershipsList;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+@Testcontainers
+@Tag("integration-test")
+class AcspMembersServiceIntegrationTest {
+
+  @Container @ServiceConnection
+  private static MongoDBContainer container = new MongoDBContainer("mongo:5");
+
+  @Autowired private MongoTemplate mongoTemplate;
+
+  @MockBean private ApiClientService apiClientService;
+
+  @MockBean private InternalApiClient internalApiClient;
+
+  @MockBean StaticPropertyUtil staticPropertyUtil;
+
+  private final TestDataManager testDataManager = TestDataManager.getInstance();
+
+  @Autowired private AcspMembersService acspMembersService;
+
+  @Autowired private AcspMembersRepository acspMembersRepository;
+
+  @MockBean private AcspMembershipListMapper acspMembershipsListMapper;
+
+  private User testUser;
+
+  @BeforeEach
+  void setUp() {
+    testUser = new User();
+    testUser.setUserId("COMU002");
+
+    acspMembersRepository.deleteAll();
+
+    AcspMembersDao activeMember =
+        createAcspMembersDao(
+            "1", "ACSP001", testUser.getUserId(), AcspMembership.UserRoleEnum.ADMIN, false);
+    AcspMembersDao removedMember =
+        createAcspMembersDao(
+            "2", "ACSP002", testUser.getUserId(), AcspMembership.UserRoleEnum.STANDARD, true);
+
+    acspMembersRepository.save(activeMember);
+    acspMembersRepository.save(removedMember);
+
+    when(acspMembershipsListMapper.daoToDto(anyList(), eq(testUser)))
+        .thenAnswer(
+            invocation -> {
+              List<AcspMembersDao> daos = invocation.getArgument(0);
+              return daos.stream()
+                  .map(
+                      dao -> {
+                        AcspMembership membership = new AcspMembership();
+                        membership.setAcspNumber(dao.getAcspNumber());
+                        membership.setUserRole(
+                            AcspMembership.UserRoleEnum.fromValue(dao.getUserRole()));
+                        return membership;
+                      })
+                  .toList();
+            });
+  }
+
+  private AcspMembersDao createAcspMembersDao(
+      String id,
+      String acspNumber,
+      String userId,
+      AcspMembership.UserRoleEnum userRole,
+      boolean removed) {
+    AcspMembersDao dao = new AcspMembersDao();
+    dao.setId(id);
+    dao.setAcspNumber(acspNumber);
+    dao.setUserId(userId);
+    dao.setUserRole(userRole.toString());
+    dao.setCreatedAt(LocalDateTime.now());
+    dao.setAddedAt(LocalDateTime.now());
+    dao.setAddedBy("testAdder");
+    if (removed) {
+      dao.setRemovedAt(LocalDateTime.now());
+      dao.setRemovedBy("testRemover");
+    }
+    dao.setEtag("testEtag");
+    return dao;
+  }
+
+  @Test
+  void fetchAcspMembershipsReturnsAcspMembershipsListWithAllAcspMembersIfIncludeRemovedTrue() {
+    AcspMembershipsList result = acspMembersService.fetchAcspMemberships(testUser, true);
+
+    assertEquals(2, result.getItems().size());
+    assertTrue(result.getItems().stream().anyMatch(m -> m.getAcspNumber().equals("ACSP001")));
+    assertTrue(result.getItems().stream().anyMatch(m -> m.getAcspNumber().equals("ACSP002")));
+  }
+
+  @Test
+  void fetchAcspMembershipsReturnsAcspMembershipsListWithActiveAcspMembersIfIncludeRemovedFalse() {
+    AcspMembershipsList result = acspMembersService.fetchAcspMemberships(testUser, false);
+
+    assertEquals(1, result.getItems().size());
+    assertTrue(result.getItems().stream().anyMatch(m -> m.getAcspNumber().equals("ACSP001")));
+  }
+
+  @Test
+  void
+      fetchAcspMembershipsReturnsAcspMembershipsListWithEmptyListIfNoMembershipsAndIncludeRemovedTrue() {
+    testUser.setUserId("X666");
+    AcspMembershipsList result = acspMembersService.fetchAcspMemberships(testUser, true);
+
+    assertTrue(result.getItems().isEmpty());
+  }
+
+  @Test
+  void
+      fetchAcspMembershipsReturnsAcspMembershipsListWithEmptyListIfNoMembershipsAndIncludeRemovedFalse() {
+    testUser.setUserId("X666");
+    AcspMembershipsList result = acspMembersService.fetchAcspMemberships(testUser, false);
+
+    assertTrue(result.getItems().isEmpty());
+  }
+}

--- a/src/test/java/uk/gov/companieshouse/acsp/manage/users/integration/UserAcspMembershipControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/manage/users/integration/UserAcspMembershipControllerIntegrationTest.java
@@ -1,0 +1,196 @@
+package uk.gov.companieshouse.acsp.manage.users.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.gov.companieshouse.acsp.manage.users.common.TestDataManager;
+import uk.gov.companieshouse.acsp.manage.users.model.AcspMembersDao;
+import uk.gov.companieshouse.acsp.manage.users.repositories.AcspMembersRepository;
+import uk.gov.companieshouse.acsp.manage.users.service.AcspDataService;
+import uk.gov.companieshouse.acsp.manage.users.service.UsersService;
+import uk.gov.companieshouse.acsp.manage.users.utils.StaticPropertyUtil;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembershipsList;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Testcontainers
+@ExtendWith(MockitoExtension.class)
+@Tag("integration-test")
+class UserAcspMembershipControllerIntegrationTest {
+  @Container @ServiceConnection static MongoDBContainer container = new MongoDBContainer("mongo:5");
+
+  @Autowired MongoTemplate mongoTemplate;
+
+  @Autowired public MockMvc mockMvc;
+
+  @MockBean ApiClientService apiClientService;
+
+  @MockBean InternalApiClient internalApiClient;
+
+  @MockBean StaticPropertyUtil staticPropertyUtil;
+
+  @MockBean private UsersService usersService;
+
+  @MockBean private AcspDataService acspDataService;
+
+  @Autowired private AcspMembersRepository acspMembersRepository;
+
+  private final TestDataManager testDataManager = TestDataManager.getInstance();
+  private String testUserId;
+
+  private void mockFetchUserDetailsFor(String... userIds) {
+    Arrays.stream(userIds)
+        .forEach(
+            userId ->
+                Mockito.doReturn(testDataManager.fetchUserDtos(userId).getFirst())
+                    .when(usersService)
+                    .fetchUserDetails(userId));
+  }
+
+  private void mockFetchAcspDataFor(String... acspNumbers) {
+    Arrays.stream(acspNumbers)
+        .forEach(
+            acspNumber ->
+                Mockito.doReturn(testDataManager.fetchAcspDataDaos(acspNumber).getFirst())
+                    .when(acspDataService)
+                    .fetchAcspData(acspNumber));
+  }
+
+  @BeforeEach
+  void setUp() {
+    testUserId = "COMU002";
+  }
+
+  @AfterEach
+  public void after() {
+    mongoTemplate.dropCollection(AcspMembersDao.class);
+  }
+
+  @Test
+  void getAcspMembershipsForUserIdWithoutXRequestIdReturnsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            get("/user/acsps/memberships")
+                .header("Eric-identity", testUserId)
+                .header("ERIC-Identity-Type", "oauth2")
+                .header("ERIC-Authorised-Key-Roles", "*"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void getAcspMembershipsForUserIdWithWrongIncludeRemovedParameterInBodyReturnsBadRequest()
+      throws Exception {
+    mockMvc
+        .perform(
+            get("/user/acsps/memberships?include_removed=null")
+                .header("X-Request-Id", "theId123")
+                .header("Eric-identity", testUserId)
+                .header("ERIC-Identity-Type", "oauth2")
+                .header("ERIC-Authorised-Key-Roles", "*"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void getAcspMembershipsForUserIdWhoHasNoAcspMemebershipsReturnsEmptyAcspMembershipsList()
+      throws Exception {
+    // Given
+    final var acspMemberDaos =
+        testDataManager.fetchAcspMembersDaos(
+            "COM001", "COM003", "COM004", "COM005", "COM006", "COM007", "COM008", "COM009",
+            "COM010", "COM011", "COM012", "COM013", "COM014", "COM015", "COM016");
+
+    acspMembersRepository.insert(acspMemberDaos);
+    acspMembersRepository.insert(testDataManager.fetchAcspMembersDaos("TS001", "TS002"));
+    mockFetchUserDetailsFor(
+        "COMU001", "COMU002", "COMU003", "COMU004", "COMU005", "COMU006", "COMU007", "COMU008",
+        "COMU009", "COMU010", "COMU011", "COMU012", "COMU013", "COMU014", "COMU015", "COMU016");
+    mockFetchAcspDataFor("COMA001");
+    // When
+    final var response =
+        mockMvc
+            .perform(
+                get("/user/acsps/memberships")
+                    .header("X-Request-Id", "theId123")
+                    .header("Eric-identity", testUserId)
+                    .header("ERIC-Identity-Type", "oauth2")
+                    .header("ERIC-Authorised-Key-Roles", "*"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse();
+
+    final var objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    final var acspMembershipsList =
+        objectMapper.readValue(response.getContentAsString(), AcspMembershipsList.class);
+
+    final var acspMemberships = acspMembershipsList.getItems();
+    // Then
+    assertTrue(acspMemberships.isEmpty());
+  }
+
+  @Test
+  void getAcspMembershipsForUserIdWhoHasAcspMemebershipsReturnsNonEmptyAcspMembershipsList()
+      throws Exception {
+    // Given
+    final var acspMemberDaos =
+        testDataManager.fetchAcspMembersDaos(
+            "COM001", "COM002", "COM003", "COM004", "COM005", "COM006", "COM007", "COM008",
+            "COM009", "COM010", "COM011", "COM012", "COM013", "COM014", "COM015", "COM016");
+
+    acspMembersRepository.insert(acspMemberDaos);
+    acspMembersRepository.insert(testDataManager.fetchAcspMembersDaos("TS001", "TS002"));
+    mockFetchUserDetailsFor(
+        "COMU001", "COMU002", "COMU003", "COMU004", "COMU005", "COMU006", "COMU007", "COMU008",
+        "COMU009", "COMU010", "COMU011", "COMU012", "COMU013", "COMU014", "COMU015", "COMU016");
+    mockFetchAcspDataFor("COMA001");
+    // When
+    final var response =
+        mockMvc
+            .perform(
+                get("/user/acsps/memberships")
+                    .header("X-Request-Id", "theId123")
+                    .header("Eric-identity", testUserId)
+                    .header("ERIC-Identity-Type", "oauth2")
+                    .header("ERIC-Authorised-Key-Roles", "*"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse();
+
+    final var objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    final var acspMembershipsList =
+        objectMapper.readValue(response.getContentAsString(), AcspMembershipsList.class);
+
+    final var acspMemberships = acspMembershipsList.getItems();
+    // Then
+    assertEquals(1, acspMemberships.size());
+    assertEquals("COM002", acspMemberships.getFirst().getId());
+    assertEquals(testUserId, acspMemberships.getFirst().getUserId());
+    assertEquals("COMA001", acspMemberships.getFirst().getAcspNumber());
+  }
+}

--- a/src/test/java/uk/gov/companieshouse/acsp/manage/users/service/AcspMembersServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/manage/users/service/AcspMembersServiceTest.java
@@ -1,0 +1,127 @@
+package uk.gov.companieshouse.acsp.manage.users.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.acsp.manage.users.mapper.AcspMembershipListMapper;
+import uk.gov.companieshouse.acsp.manage.users.model.AcspMembersDao;
+import uk.gov.companieshouse.acsp.manage.users.repositories.AcspMembersRepository;
+import uk.gov.companieshouse.api.accounts.user.model.User;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembership;
+import uk.gov.companieshouse.api.acsp_manage_users.model.AcspMembershipsList;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit-test")
+class AcspMembersServiceTest {
+
+  @Mock private AcspMembersRepository acspMembersRepository;
+
+  @Mock private AcspMembershipListMapper acspMembershipsListMapper;
+
+  @InjectMocks private AcspMembersService acspMembersService;
+
+  private User testUser;
+  private List<AcspMembersDao> testActiveAcspMembersDaos;
+  private List<AcspMembersDao> testAllAcspMembersDaos;
+  private List<AcspMembership> testAcspMemberships;
+
+  @BeforeEach
+  void setUp() {
+    testUser = new User();
+    testUser.setUserId("COMU002");
+    testActiveAcspMembersDaos = List.of(createAcspMembersDao("1", false));
+    testAllAcspMembersDaos =
+        Arrays.asList(createAcspMembersDao("1", false), createAcspMembersDao("2", true));
+    testAcspMemberships = Arrays.asList(new AcspMembership(), new AcspMembership());
+  }
+
+  private AcspMembersDao createAcspMembersDao(String id, boolean removed) {
+    AcspMembersDao dao = new AcspMembersDao();
+    dao.setId(id);
+    dao.setRemovedBy(removed ? "remover" : null);
+    return dao;
+  }
+
+  @Test
+  void fetchAcspMembershipsReturnsAcspMembershipsListWithAllAcspMembersIfIncludeRemovedTrue() {
+    // Given
+    when(acspMembersRepository.fetchAllAcspMembersByUserId(testUser.getUserId()))
+        .thenReturn(testAllAcspMembersDaos);
+    when(acspMembershipsListMapper.daoToDto(testAllAcspMembersDaos, testUser))
+        .thenReturn(testAcspMemberships);
+    // When
+    AcspMembershipsList result = acspMembersService.fetchAcspMemberships(testUser, true);
+    // Then
+    assertNotNull(result);
+    assertEquals(2, result.getItems().size());
+    assertSame(testAcspMemberships, result.getItems());
+    verify(acspMembersRepository).fetchAllAcspMembersByUserId(testUser.getUserId());
+    verify(acspMembershipsListMapper).daoToDto(testAllAcspMembersDaos, testUser);
+    verifyNoMoreInteractions(acspMembersRepository, acspMembershipsListMapper);
+  }
+
+  @Test
+  void fetchAcspMembershipsReturnsAcspMembershipsListWithActiveAcspMembersIfIncludeRemovedFalse() {
+    // Given
+    when(acspMembersRepository.fetchActiveAcspMembersByUserId(testUser.getUserId()))
+        .thenReturn(testActiveAcspMembersDaos);
+    when(acspMembershipsListMapper.daoToDto(testActiveAcspMembersDaos, testUser))
+        .thenReturn(Collections.singletonList(testAcspMemberships.getFirst()));
+    // When
+    AcspMembershipsList result = acspMembersService.fetchAcspMemberships(testUser, false);
+    // Then
+    assertNotNull(result);
+    assertEquals(1, result.getItems().size());
+    assertSame(testAcspMemberships.getFirst(), result.getItems().getFirst());
+    verify(acspMembersRepository).fetchActiveAcspMembersByUserId(testUser.getUserId());
+    verify(acspMembershipsListMapper).daoToDto(testActiveAcspMembersDaos, testUser);
+    verifyNoMoreInteractions(acspMembersRepository, acspMembershipsListMapper);
+  }
+
+  @Test
+  void
+      fetchAcspMembershipsReturnsAcspMembershipsListWithEmptyListIfNoMembershipsAndIncludeRemovedTrue() {
+    // Given
+    when(acspMembersRepository.fetchAllAcspMembersByUserId(testUser.getUserId()))
+        .thenReturn(Collections.emptyList());
+    when(acspMembershipsListMapper.daoToDto(Collections.emptyList(), testUser))
+        .thenReturn(Collections.emptyList());
+    // When
+    AcspMembershipsList result = acspMembersService.fetchAcspMemberships(testUser, true);
+    // Then
+    assertNotNull(result);
+    assertTrue(result.getItems().isEmpty());
+    verify(acspMembersRepository).fetchAllAcspMembersByUserId(testUser.getUserId());
+    verify(acspMembershipsListMapper).daoToDto(Collections.emptyList(), testUser);
+    verifyNoMoreInteractions(acspMembersRepository, acspMembershipsListMapper);
+  }
+
+  @Test
+  void
+      fetchAcspMembershipsReturnsAcspMembershipsListWithEmptyListIfNoMembershipsAndIncludeRemovedFalse() {
+    // Given
+    when(acspMembersRepository.fetchActiveAcspMembersByUserId(testUser.getUserId()))
+        .thenReturn(Collections.emptyList());
+    when(acspMembershipsListMapper.daoToDto(Collections.emptyList(), testUser))
+        .thenReturn(Collections.emptyList());
+    // When
+    AcspMembershipsList result = acspMembersService.fetchAcspMemberships(testUser, false);
+    // Then
+    assertNotNull(result);
+    assertTrue(result.getItems().isEmpty());
+    verify(acspMembersRepository).fetchActiveAcspMembersByUserId(testUser.getUserId());
+    verify(acspMembershipsListMapper).daoToDto(Collections.emptyList(), testUser);
+    verifyNoMoreInteractions(acspMembersRepository, acspMembershipsListMapper);
+  }
+}


### PR DESCRIPTION
Implementation of the endpoint for fetching ACSP memberships for the logged-in user.

https://companieshouse.atlassian.net/browse/IDVA6-1322

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__