### PR TITLE
Idva6 1348 added composite interceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/acsp/manage/users/configuration/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/manage/users/configuration/InterceptorConfig.java
@@ -5,6 +5,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.acsp.manage.users.interceptor.AuthorizationInterceptor;
+import uk.gov.companieshouse.acsp.manage.users.interceptor.CompositeInterceptor;
 import uk.gov.companieshouse.acsp.manage.users.interceptor.LoggingInterceptor;
 import uk.gov.companieshouse.acsp.manage.users.utils.StaticPropertyUtil;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
@@ -12,10 +13,9 @@ import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 @Configuration
 public class InterceptorConfig implements WebMvcConfigurer {
 
-  private static final String OAUTH_PROTECTED_ENDPOINTS = "/acsp-members/**";
-  private static final String OAUTH_PROTECTED_ENDPOINTS_BASE = "/acsp-members";
-  private static final String KEY_PROTECTED_ENDPOINTS = "/internal/acsp-members/**";
-  private static final String HEALTH_CHECK_ENDPOINT = "/*/healthcheck";
+    private static final String OAUTH_PROTECTED_ENDPOINTS = "/acsp-members/user/**";
+    private static final String OAUTH_AND_KEY_PROTECTED_ENDPOINTS = "/acsp-members/acsps/**";
+    private static final String HEALTH_CHECK_ENDPOINT = "/*/healthcheck";
 
     private final LoggingInterceptor loggingInterceptor;
     private final AuthorizationInterceptor authorizationInterceptor;
@@ -36,13 +36,12 @@ public class InterceptorConfig implements WebMvcConfigurer {
     }
 
     private void addEricInterceptors(final InterceptorRegistry registry) {
-    registry
-        .addInterceptor(authorizationInterceptor)
-        .addPathPatterns(OAUTH_PROTECTED_ENDPOINTS, OAUTH_PROTECTED_ENDPOINTS_BASE)
-        .excludePathPatterns(HEALTH_CHECK_ENDPOINT, KEY_PROTECTED_ENDPOINTS);
+    registry.addInterceptor( authorizationInterceptor )
+            .addPathPatterns( OAUTH_PROTECTED_ENDPOINTS )
+            .excludePathPatterns( HEALTH_CHECK_ENDPOINT, OAUTH_AND_KEY_PROTECTED_ENDPOINTS );
 
-        registry.addInterceptor( new InternalUserInterceptor( StaticPropertyUtil.APPLICATION_NAMESPACE ) )
-                .addPathPatterns( KEY_PROTECTED_ENDPOINTS )
+        registry.addInterceptor( new CompositeInterceptor( authorizationInterceptor, new InternalUserInterceptor( StaticPropertyUtil.APPLICATION_NAMESPACE ) ) )
+                .addPathPatterns( OAUTH_AND_KEY_PROTECTED_ENDPOINTS )
                 .excludePathPatterns( HEALTH_CHECK_ENDPOINT, OAUTH_PROTECTED_ENDPOINTS );
     }
 

--- a/src/main/java/uk/gov/companieshouse/acsp/manage/users/configuration/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/manage/users/configuration/InterceptorConfig.java
@@ -13,8 +13,8 @@ import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 @Configuration
 public class InterceptorConfig implements WebMvcConfigurer {
 
-    private static final String OAUTH_PROTECTED_ENDPOINTS = "/acsp-members/user/**";
-    private static final String OAUTH_AND_KEY_PROTECTED_ENDPOINTS = "/acsp-members/acsps/**";
+    private static final String OAUTH_PROTECTED_ENDPOINTS = "/user/**";
+    private static final String OAUTH_AND_KEY_PROTECTED_ENDPOINTS = "/acsps/**";
     private static final String HEALTH_CHECK_ENDPOINT = "/*/healthcheck";
 
     private final LoggingInterceptor loggingInterceptor;

--- a/src/main/java/uk/gov/companieshouse/acsp/manage/users/interceptor/CompositeInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/manage/users/interceptor/CompositeInterceptor.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.acsp.manage.users.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class CompositeInterceptor implements HandlerInterceptor {
+
+    private List<HandlerInterceptor> interceptors = new LinkedList<>();
+
+    public CompositeInterceptor( HandlerInterceptor... interceptors ){
+        this.interceptors.addAll( Arrays.asList( interceptors ) );
+    }
+
+    @Override
+    public boolean preHandle( HttpServletRequest request, HttpServletResponse response, Object handler ) throws Exception {
+        var errorResponseCode = 401;
+        for ( HandlerInterceptor interceptor: interceptors ){
+            if( interceptor.preHandle( request, response, handler ) ){
+                return true;
+            }
+            if ( response.getStatus() == 403 ){
+                errorResponseCode = 403;
+            }
+        }
+        response.setStatus( errorResponseCode );
+        return false;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/acsp/manage/users/interceptor/CompositeInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/manage/users/interceptor/CompositeInterceptorTest.java
@@ -1,0 +1,92 @@
+package uk.gov.companieshouse.acsp.manage.users.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import uk.gov.companieshouse.acsp.manage.users.exceptions.NotFoundRuntimeException;
+import uk.gov.companieshouse.acsp.manage.users.service.UsersService;
+import uk.gov.companieshouse.api.accounts.user.model.User;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
+
+@ExtendWith( MockitoExtension.class )
+@Tag( "unit-test" )
+class CompositeInterceptorTest {
+
+    @Mock
+    private UsersService usersService;
+
+    private AuthorizationInterceptor authorizationInterceptor;
+
+    private InternalUserInterceptor internalUserInterceptor;
+
+    private CompositeInterceptor compositeInterceptor;
+
+    @BeforeEach
+    void setup(){
+        authorizationInterceptor = new AuthorizationInterceptor( usersService );
+        internalUserInterceptor = new InternalUserInterceptor();
+        compositeInterceptor = new CompositeInterceptor( authorizationInterceptor, internalUserInterceptor );
+    }
+
+    @Test
+    void preHandleWithoutEricHeadersReturnsUnauthorised() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        HttpServletResponse response = new MockHttpServletResponse();
+        assertFalse( compositeInterceptor.preHandle(request, response, null) );
+        assertEquals(401, response.getStatus() );
+    }
+
+    @Test
+    void preHandleWithMalformedRequestReturnsForbidden() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Eric-Identity", "$$$");
+        request.addHeader( "ERIC-Identity-Type", "oauth2" );
+
+        Mockito.doThrow( new NotFoundRuntimeException( "accounts-association-api", "Not found" ) ).when( usersService ).fetchUserDetails( "$$$" );
+
+        HttpServletResponse response = new MockHttpServletResponse();
+        assertFalse( compositeInterceptor.preHandle(request, response, null) );
+        assertEquals(403, response.getStatus() );
+    }
+
+    @Test
+    void preHandleWithWellFormedOAuth2RequestSucceeds() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Eric-identity", "111");
+        request.addHeader("Eric-identity-type", "oauth2");
+
+        final var bruce = new User()
+                .userId( "111" )
+                .email( "bruce.wayne@gotham.city" )
+                .displayName( "Batman" );
+
+        Mockito.doReturn( bruce ).when( usersService ).fetchUserDetails( "111" );
+
+        HttpServletResponse response = new MockHttpServletResponse();
+        assertTrue( compositeInterceptor.preHandle(request, response, null) );
+    }
+
+    @Test
+    void preHandleWithWellFormedApiKeyRequestSucceeds() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Eric-identity", "111");
+        request.addHeader("Eric-identity-type", "key");
+        request.addHeader("ERIC-Authorised-Key-Roles","*");
+
+        HttpServletResponse response = new MockHttpServletResponse();
+        assertTrue( compositeInterceptor.preHandle(request, response, null) );
+    }
+
+}


### PR DESCRIPTION
__Short description outlining key changes/additions__

Created a new CompositeInterceptor. One can add any interceptors to this CompositeInterceptor. The CompositeInterceptor will run the interceptors that it has been given and compute the appropriate aggregate result. This CompositeInterceptor is now being used in the InterceptorConfig, so that the AuthorizationInterceptor and InternalUserInterceptor are mutually exclusively applied to five of the endpoints. InterceptorConfig has also been updated to only apply AuthorizationInterceptor to one of the endpoints.

Chose to use CompositeInterceptor approach, because it will make swapping AuthorizationInterceptor for RolePermissionInterceptor easier.

__JIRA Ticket Number__

IDVA6-1348

### Type of change

* [x] Bug fix
* [x] New feature
* [x] Breaking change
* [x] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__